### PR TITLE
This will make Separator display by default

### DIFF
--- a/components/separator/files/index.blade.php
+++ b/components/separator/files/index.blade.php
@@ -34,7 +34,7 @@
         {{-- we need to make the element can contributes to space-y-* likely if we don't use flex --}}
         <div 
             data-orientation="{{ $orientation }}" 
-            {{ $attributes }} 
+            {{ $attributes->class('w-full') }} 
             data-slot="separator"
             role="separator" 
             aria-orientation="{{ $orientation }}"


### PR DESCRIPTION
The Separator component currently renders only when it has an explicit width or when its parent defines one, for example:

`<x-ui.separator class="w-full" />`

or
```
<div class="w-full">
    <x-ui.separator />
</div>
```

This update ensures that the Separator displays by default without requiring a width to be set on itself or its parent.