### PR TITLE
fix: added teleport attribute to prevent livewire conflicts

### DIFF
--- a/components/dropdown/files/index.blade.php
+++ b/components/dropdown/files/index.blade.php
@@ -1,5 +1,6 @@
 @props([
     'position' => 'bottom-center',
+    'teleport' => 'body',
     'portal' => false 
 ])
 
@@ -75,7 +76,7 @@
         </div>
         
         @if($portal)
-            <template x-teleport="body">
+            <template x-teleport="{{ $teleport }}">
         @endif
         
         <div 


### PR DESCRIPTION
## Fix
Added a `teleport` prop to the `<x-ui.dropdown>` component. When enabled, it uses `<template x-teleport="body">` to move the dropdown's DOM out of the Livewire-managed tree.

This prevents Livewire and Alpine from conflicting over the same DOM elements.