### PR TITLE
premature escaping in select ui

### DIFF
--- a/components/select/files/index.blade.php
+++ b/components/select/files/index.blade.php
@@ -73,7 +73,7 @@
                         .from(this.$el.querySelectorAll('[data-slot=option]:not([hidden])'))
                         .map((option) => ({
                             value: option.dataset.value,
-                            label: option.dataset.label,
+                            label: option.textContent.trim(),
                             element: option
                         }));
 

--- a/components/select/files/option.blade.php
+++ b/components/select/files/option.blade.php
@@ -11,11 +11,6 @@
     'iconClass' => null,
 ])
 
-@php
-    // if there no label provided (when the value is the same as label) give the slot the value's value
-    $slot = filled($slot->__toString()) ? $slot->__toString() : $value;
-@endphp
-
 <li 
     
     tabindex="0"


### PR DESCRIPTION
when using " in my database it's always shows &quot: and other, 've tried to change these, is it ok?