### PR TITLE
docs(rover): clarify import order requirement

### DIFF
--- a/primitives/rover.md
+++ b/primitives/rover.md
@@ -24,6 +24,9 @@ Register it before Alpine starts.
 npm i @sheaf/rover
 ```
 
+> When using the Rover primitive (with either Livewire or Alpine), ensure it is imported **before** any Sheaf UI components that depend on it.
+
+
 **With Livewire:**
 ```js
 import { Livewire, Alpine } from "../../vendor/livewire/livewire/dist/livewire.esm"


### PR DESCRIPTION
## What
Clarifies that the Rover primitive must be imported before dependent components.

## Why
Import order is required for proper functionality but was not clearly documented.