### PR TITLE
Added more size options to heading component and removed text-center class

### DIFF
--- a/components/heading/files/index.blade.php
+++ b/components/heading/files/index.blade.php
@@ -1,3 +1,4 @@
+{{-- resources/views/components/ui/heading/index.blade.php --}}
 @props([
     'level' => 'h2',
     'size' => 'sm',
@@ -12,11 +13,14 @@
         'md' => 'text-lg',
         'lg' => 'text-xl',
         'xl' => 'text-2xl',
+        '2xl' => 'text-4xl',
+        '3xl' => 'text-6xl',
+        '4xl' => 'text-8xl',
         default => 'text-base'
     };
 
     $classes = [
-        'font-semibold text-neutral-800 dark:text-white text-start',
+        'font-semibold font-lemonmilk text-neutral-800 dark:text-white',
         $variantClasses
     ];
 

--- a/components/heading/files/index.blade.php
+++ b/components/heading/files/index.blade.php
@@ -20,7 +20,7 @@
     };
 
     $classes = [
-        'font-semibold font-lemonmilk text-neutral-800 dark:text-white',
+        'font-semibold text-neutral-800 dark:text-white',
         $variantClasses
     ];
 


### PR DESCRIPTION
Problems:
- text-center class being present meant adjusting the text alignment required all alignment classes passed to be prefixed with "!"
- Limited size options for heading, largest size was still fairly small.

Past and new sizes seen together👇
<img width="433" height="360" alt="image" src="https://github.com/user-attachments/assets/bc012d1a-9158-401f-9516-5db79b4e0e39" />

Solution:
Now the user can choose from an additional 3 sizes.
Now the user can pass classes like "text-center" without prefixing or affixing "!".
