### PR TITLE
fix(otp): make the code fillable by password managers and submittable in a plain form

### DIFF
--- a/components/otp/files/index.blade.php
+++ b/components/otp/files/index.blade.php
@@ -330,4 +330,11 @@
             @endif
         </div>
     </div>
+
+    {{-- What a plain <form> submits. The boxes carry no name of their own: a name
+         on each of them posts one value per box and the last one wins. Livewire
+         binds through wire:model instead, and needs no field here. --}}
+    @if (filled($name) && ! $modelAttrs)
+        <input type="hidden" name="{{ $name }}" x-bind:value="_state" />
+    @endif
 </div>

--- a/components/otp/files/index.blade.php
+++ b/components/otp/files/index.blade.php
@@ -93,16 +93,22 @@
                 this._inputs.forEach((input, index) => {
                     input.setAttribute('data-order', index);
                     input.setAttribute('aria-label', `Digit ${index + 1} of ${this.length}`);
+
+                    // Only the first box claims the code. Six boxes all answering to
+                    // `one-time-code` leave a password manager no single field to fill.
+                    input.setAttribute('autocomplete', index === 0 ? 'one-time-code' : 'off');
                 });
             },
 
-            // Enable only the next valid input (lock the rest)
+            // Keep tabbing on the next valid input (skip the rest)
             updateInputAvailability() {
-                // Inputs are enabled only up to (filled count + 1)
+                // Inputs are in play only up to (filled count + 1)
                 const enableCount = this._state.length < this.length ? this._state.length + 1 : this.length;
 
                 this._inputs.forEach((input, index) => {
-                    input.disabled = index >= enableCount;
+                    // Not `disabled`: a disabled input is one a password manager
+                    // cannot write to, so a fill stops at the first box.
+                    input.tabIndex = index >= enableCount ? -1 : 0;
                 });
             },
 
@@ -116,10 +122,12 @@
                 const index = parseInt(el.dataset.order);
                 let value = el.value;
 
-                // Always keep last typed character (avoid multi-char paste in one box)
+                // A password manager fills the whole code into one box and dispatches
+                // `input`, never `paste` — so this is the only place that sees it.
                 if (value.length > 1) {
-                    value = value.slice(-1);
-                    el.value = value;
+                    this.fillFrom(value, index);
+
+                    return;
                 }
 
                 // Reject characters not matching the pattern
@@ -140,12 +148,16 @@
 
             // Handle paste: distribute valid chars across remaining inputs
             handlePaste(e) {
-                const pasted = e.clipboardData.getData('text');
-                const regex = new RegExp(`^${this.allowedPattern}$`);
-                const validChars = Array.from(pasted).filter(char => regex.test(char));
-                const startIndex = parseInt(e.target.dataset.order);
+                this.fillFrom(e.clipboardData.getData('text'), parseInt(e.target.dataset.order));
+            },
 
-                // Clear all inputs after paste start position
+            // Spread a multi-character value across the boxes from one of them on.
+            // Both a paste and a password manager's fill arrive here.
+            fillFrom(text, startIndex) {
+                const regex = new RegExp(`^${this.allowedPattern}$`);
+                const validChars = Array.from(text).filter(char => regex.test(char));
+
+                // Clear all inputs after the start position
                 for (let i = startIndex; i < this._inputs.length; i++) {
                     this._inputs[i].value = '';
                 }
@@ -165,7 +177,7 @@
                     if (next) {
                         this.focusAndSelect(next);
                     } else if (validChars.length + startIndex >= this.length) {
-                        // If paste fills all boxes, focus last input for convenience
+                        // If the fill covers all boxes, focus last input for convenience
                         const lastInput = this._inputs[this.length - 1];
                         if (lastInput) {
                             requestAnimationFrame(() => {
@@ -252,15 +264,18 @@
 
             // Public method: Clear all inputs and reset focus
             clear() {
+                const held = this._inputs.includes(document.activeElement);
+
                 this._inputs.forEach(input => {
                     input.value = '';
-                    input.disabled = true;
                 });
 
-                if (this._inputs[0]) this._inputs[0].disabled = false;
+                // Resetting the state is what restores the tab order
                 this._state = '';
 
-                if (this.autofocus && this._inputs[0]) {
+                // The caret goes back to the first box rather than being left on
+                // one that is no longer in play
+                if ((this.autofocus || held) && this._inputs[0]) {
                     requestAnimationFrame(() => this._inputs[0].focus());
                 }
             },
@@ -273,26 +288,14 @@
 
             // Handle clicks anywhere inside the container (smart focus delegation)
             handleClick(e) {
+                // Clamped to the boxes in play rather than gated on `disabled`, which
+                // nothing sets any more: a click past the caret lands on the first
+                // box still waiting for a digit.
                 const clickedInput = e.target.closest('[data-slot=otp-input]');
+                const furthest = Math.min(this._state.length, this.length - 1);
+                const order = clickedInput ? parseInt(clickedInput.dataset.order) : furthest;
 
-                // If clicked directly on an active input
-                if (clickedInput && !clickedInput.disabled) {
-                    this.focusAndSelect(clickedInput);
-                    return;
-                }
-
-                // Otherwise, find the best input to focus next
-                const firstEmpty = this._inputs.find(input => !input.value && !input.disabled);
-
-                if (firstEmpty) {
-                    this.focusAndSelect(firstEmpty);
-                } else {
-                    // All filled: focus last for easy editing
-                    const lastInput = this._inputs[this.length - 1];
-                    if (lastInput && !lastInput.disabled) {
-                        this.focusAndSelect(lastInput);
-                    }
-                }
+                this.focusAndSelect(this._inputs[Math.min(order, furthest)]);
             }
         }
     }"

--- a/components/otp/files/index.blade.php
+++ b/components/otp/files/index.blade.php
@@ -4,6 +4,7 @@
     'type' => 'text',
     'allowedPattern' => '[0-9]',
     'autofocus' => false,
+    'required' => true,
 ])
 
 @php

--- a/components/otp/files/input.blade.php
+++ b/components/otp/files/input.blade.php
@@ -1,4 +1,4 @@
-@aware(['type' => 'text','name'=> null])
+@aware(['type' => 'text'])
 
 @php
 $classes = [
@@ -21,7 +21,6 @@ $classes = [
 <input
     {{ $attributes
         ->merge([
-            'name' => $name,
             'type' => $type,
         ])
         ->class($classes) 

--- a/components/otp/files/input.blade.php
+++ b/components/otp/files/input.blade.php
@@ -39,7 +39,9 @@ $classes = [
     x-on:keydown.backspace.prevent="await handleBackspace($event)"
     
     {{-- accessibilty addons --}}
-    autocomplete="one-time-code"
+    {{-- index.blade.php gives the first box `one-time-code`; the rest stay off, so
+         a password manager has one field to aim at rather than six. --}}
+    autocomplete="off"
     x-on:keydown.right="$focus.within($refs.inputsWrapper).next()"
     x-on:keydown.up="$focus.within($refs.inputsWrapper).next()"
     x-on:keydown.left="$focus.within($refs.inputsWrapper).prev()"

--- a/components/otp/files/input.blade.php
+++ b/components/otp/files/input.blade.php
@@ -1,4 +1,4 @@
-@aware(['type' => 'text'])
+@aware(['type' => 'text', 'required' => true])
 
 @php
 $classes = [
@@ -26,7 +26,7 @@ $classes = [
         ->class($classes) 
     }}
     
-    required
+    @if ($required) required @endif
     maxlength="1"
     data-slot="otp-input"
     x-on:input="handleInput($el)"

--- a/components/otp/usage.md
+++ b/components/otp/usage.md
@@ -69,6 +69,22 @@ You can use it outside Livewire with just Alpine (with Blade):
 
 > **Note:** The component uses `_state` and `_inputs` internally, so avoid using these variable names in your Alpine scope.
 
+#### Submitting from a plain form
+
+Outside Livewire the component submits through a hidden input, named after `name` (or after the `x-model` expression when no name is given):
+
+```html
+<form method="POST" action="/two-factor-challenge" x-data="{ code: null }">
+    @csrf
+
+    <x-ui.otp name="code" x-model="code" :length="6" />
+
+    <button type="submit">Continue</button>
+</form>
+```
+
+> **Note:** If the OTP shares a form with another field and is hidden behind `x-show`, pass `:required="false"` or wrap it in a disabled `<fieldset>` — a `required` input that is `display: none` makes the browser refuse the submit.
+
 ## Customization
 
 ### Custom Length
@@ -288,29 +304,29 @@ When you delete a digit from the middle of the OTP, all subsequent digits automa
 - Delete `2`: `[1][3][4][ ]` (values shift left)
 - No gaps remain between digits
 
-### Click-to-Focus on Disabled Inputs
+### Click-to-Focus
 
-Click anywhere in the OTP input container, even on disabled inputs, to automatically focus the appropriate input box.
+Click anywhere in the OTP input container to automatically focus the appropriate input box.
 
 @blade
 <x-demo class="flex justify-center !text-start" x-data="{ clickCode: '12' }">
     <div>
-        <label class="block text-sm font-medium mb-2">Click on any input (even disabled ones)</label>
+        <label class="block text-sm font-medium mb-2">Click on any input</label>
         <x-ui.otp 
             x-model="clickCode"
             :length="6"
         />
-        <p class="text-sm text-neutral-600 mt-2">Try clicking on neutraled-out (disabled) inputs - focus will jump to the next available input.</p>
+        <p class="text-sm text-neutral-600 mt-2">Try clicking past the digits you have typed - focus will jump to the next available input.</p>
     </div>
 </x-demo>
 @endblade
 
 **How it works:**
-- Click on an enabled input → focuses that input
-- Click on a disabled input → focuses the first empty input
+- Click on an input at or before the caret → focuses that input
+- Click on an input past the caret → focuses the first empty input
 - Click on empty space → focuses the first empty input
 
-> **Technical Note:** This feature uses a CSS `::after` pseudo-element overlay trick to capture click events on disabled inputs, which normally block all pointer events.
+> **Technical Note:** Inputs past the caret are taken out of the tab order with `tabindex="-1"` rather than disabled, so a password manager can still fill them.
 
 ### Completion Events
 
@@ -479,7 +495,7 @@ The component exposes methods that can be called from outside:
 The component includes comprehensive accessibility features:
 
 - **ARIA labels**: Each input has a descriptive label (e.g., "Digit 1 of 4")
-- **Autocomplete**: `autocomplete="one-time-code"` for better mobile support
+- **Autocomplete**: `autocomplete="one-time-code"` on the first input, `off` on the rest, so mobile keyboards and password managers have a single field to fill
 - **Keyboard navigation**: Arrow keys move between inputs
 - **Screen reader friendly**: Proper roles and labels
 - **Focus management**: Clear visual focus indicators
@@ -492,6 +508,8 @@ The component includes comprehensive accessibility features:
 | `type` | string | `'text'` | No | HTML input type attribute |
 | `allowedPattern` | string | `'[0-9]'` | No | Regex pattern for allowed characters |
 | `autofocus` | boolean | `false` | No | Auto-focus first input on mount |
+| `name` | string | `wire:model` / `x-model` value | No | Name the code is submitted under in a plain form |
+| `required` | boolean | `true` | No | Mark the inputs required |
 | `wire:model` | string | - | Yes* | Livewire property to bind to |
 | `x-model` | string | - | Yes* | Alpine.js property to bind to |
 | `class` | string | - | No | Additional CSS classes for container |


### PR DESCRIPTION
## Summary

`x-ui.otp` cannot be filled by a password manager, and cannot be submitted by a
plain `<form>`. Both show up on Laravel's Livewire starter kit two-factor
challenge page, where between them they make two-factor login impossible: the
code either never gets typed or never reaches the server.

Comparisons below are against `<flux:otp>`, which the same starter kit page uses
and which handles all of these.

## 1. A password manager fills one digit and then appears to hang

A password manager sets `.value` and dispatches an `input` event. It does **not**
dispatch `paste`, so `handlePaste()` — the only code here that spreads a code
across the boxes — never runs. Three things then combine:

**All six boxes claim the code.** `input.blade.php` renders
`autocomplete="one-time-code"` on every box, so there is no single field to aim
at. Flux assigns it to the first input and `off` to the rest.

**A multi-character value is truncated.** The whole code arrives at
`handleInput()`, which keeps one character of it:

```js
// Always keep last typed character (avoid multi-char paste in one box)
if (value.length > 1) {
    value = value.slice(-1);
    el.value = value;
}
```

`maxlength="1"` does not prevent this — it constrains typing, not a programmatic
`.value` assignment — so `el.value` really is `"123456"` here.

**Every box ahead of the caret is `disabled`.** With an empty field only box 0 is
enabled, and a disabled input cannot be written to by an extension at all, so a
fill that goes box by box stops after the first. Flux never disables individual
boxes for this; it uses `tabindex`.

What follows looks like the keyboard locking up: `handleInput()` schedules
`$updateStateFromInputs()` in a `requestAnimationFrame`, the `_state` watcher runs
`updateInputAvailability()` and `focusAndSelect(next)`, which un-disables and then
focuses and selects in *another* frame, and `x-on:focus` runs
`requestAnimationFrame(() => $el.select())` on top. The component keeps taking
focus back frame after frame while the extension is trying to drive the field.

**Fixed by** assigning `autocomplete` per index in `setupInputs()`, moving the
distribution logic out of `handlePaste()` into a shared `fillFrom()` that
`handleInput()` also calls, and holding the caret with `tabIndex` instead of
`disabled`. `clear()` and `handleClick()` stop reading the flag back —
`handleClick()` clamps to the boxes in play, which is what `disabled` was standing
in for.

## 2. Nothing is submitted in a plain form

`name` is consumed by `@props` and read back by `otp.input` through `@aware`, so
it lands on every digit box:

```blade
{{-- input.blade.php --}}
@aware(['type' => 'text','name'=> null])
...
{{ $attributes->merge(['name' => $name, 'type' => $type]) }}
```

`<x-ui.otp name="code" length="6" />` therefore renders six `<input name="code">`.
The browser posts all six and the server keeps one — PHP's parser takes the last.
There is no field carrying the joined value.

This is invisible under `wire:model`, where Livewire is the transport. But the
starter kit posts its two-factor challenge as an ordinary form to
`two-factor.login.store` with the digits in Alpine via `x-model`, and there the
code never reaches the server at all.

**Fixed by** dropping `name` from the boxes and rendering a single hidden input
tracking `_state`, the way Flux's `<ui-otp>` does. Nothing is rendered when
`wire:model` is present, so the Livewire path is untouched.

## 3. `required` on a hidden OTP blocks its whole form

Every box is unconditionally `required`. A `required` control that is
`display: none` is still validated, so an OTP kept in the same `<form>` as an
alternative field and swapped with `x-show` makes the browser refuse the submit —
"An invalid form control with name='' is not focusable". On the starter kit page
that is the recovery-code path, which cannot be submitted at all.

**Fixed by** making `required` a prop defaulting to `true`, so nothing changes
unless a page passes `:required="false"`.

## Verification

There is no test harness in this repository, so I verified this in headless
Chrome against the component rendered before and after the change. The script is
below — it drives the two ways a password manager fills a field, and re-checks
typing, paste, backspace, click and `clear()` for regressions.

**Filling `123456`, reading back what the form would post:**

| | whole code into the field claiming `one-time-code` | one character per box |
|---|---|---|
| before | `code=6` | `code=1` |
| after | `code=123456` | `code=123456` |

**No change to anything else** (box contents after each interaction):

| | before | after |
|---|---|---|
| typing `123456` | `123456` | `123456` |
| backspace | `12345` | `12345` |
| paste `987654` | `987654` | `987654` |
| click past the caret | focus lost to `<body>` | focus clamped to box 0 |
| `otp-clear` event | cleared | cleared, focus back on box 0 |

Under `wire:model` the rendered output is unchanged apart from the box `name`
attributes, and no hidden input is added.

<details>
<summary>verify.mjs — reproduction script (puppeteer-core, system Chrome)</summary>

Render `<x-ui.otp name="code" x-model="code" length="6" />` into a page with
Alpine and its focus plugin, inside `<form id="f" x-data="{ code: '' }">`, once
per variant as `page-before.html` / `page-after.html`, then:

```js
import puppeteer from 'puppeteer-core';

const dir = process.env.SCRATCH;
const browser = await puppeteer.launch({
    executablePath: '/usr/bin/google-chrome',
    args: ['--no-sandbox', '--allow-file-access-from-files'],
});

const results = {};

for (const variant of ['before', 'after']) {
    const page = await browser.newPage();
    await page.goto(`file://${dir}/page-${variant}.html`);
    await page.waitForFunction(() => window.Alpine && document.querySelectorAll('[data-slot=otp-input]').length === 6);
    await new Promise(r => setTimeout(r, 300));

    const snapshot = async () => page.evaluate(() => {
        const boxes = [...document.querySelectorAll('[data-slot=otp-input]')];
        return {
            autocomplete: boxes.map(b => b.getAttribute('autocomplete')),
            disabled: boxes.map(b => b.disabled),
            values: boxes.map(b => b.value),
            posted: new FormData(document.getElementById('f')).get('code'),
        };
    });

    const initial = await snapshot();

    // How 1Password fills: find the field claiming the code, set .value, fire `input`.
    const filled = await page.evaluate(() => {
        const target = document.querySelector('[autocomplete="one-time-code"]')
            ?? document.querySelector('[data-slot=otp-input]');
        target.focus();
        target.value = '123456';
        target.dispatchEvent(new Event('input', { bubbles: true }));
        return target.getAttribute('data-order');
    });

    await new Promise(r => setTimeout(r, 400));
    const afterWholeCode = await snapshot();

    // The other strategy: one character per box, in a tight synchronous loop.
    await page.reload();
    await page.waitForFunction(() => window.Alpine && document.querySelectorAll('[data-slot=otp-input]').length === 6);
    await new Promise(r => setTimeout(r, 300));

    await page.evaluate(() => {
        const boxes = [...document.querySelectorAll('[data-slot=otp-input]')];
        '123456'.split('').forEach((char, i) => {
            const box = boxes[i];
            if (box.disabled) return;          // an extension cannot write to it
            box.focus();
            box.value = char;
            box.dispatchEvent(new Event('input', { bubbles: true }));
        });
    });

    await new Promise(r => setTimeout(r, 400));
    const afterPerBox = await snapshot();

    results[variant] = { initial, filledInto: filled, afterWholeCode, afterPerBox };
    await page.close();
}

await browser.close();
console.log(JSON.stringify(results, null, 2));
```

</details>

## Notes

I maintain [a migration tool](https://github.com/onelegstudios/laravel-refit) that
moves the Livewire starter kit from Flux to Sheaf, which is how I ran into all
three. It currently patches the installed component to work around them; if this
lands, that workaround goes away.

Happy to split this into separate PRs, or to drop 3 if you would rather `required`
stay unconditional.
